### PR TITLE
Cleanup library code

### DIFF
--- a/LinuxDetours/detours.cpp
+++ b/LinuxDetours/detours.cpp
@@ -2370,7 +2370,6 @@ LONG DetourTransactionCommitEx(_Out_opt_ PVOID **pppFailedPointer)
             PBYTE Ptr = (PBYTE)o->pTrampoline->Trampoline;
             for (ULONG Index = 0; Index < TrampolineSize; Index++)
             {
-#pragma warning (disable:4311) // pointer truncation
                 switch (*((ULONG*)(Ptr)))
                 {
                 /*Handle*/            case 0x1A2B3C05: *((ULONG*)Ptr) = (ULONG)o->pTrampoline; break;

--- a/LinuxDetours/detours.h
+++ b/LinuxDetours/detours.h
@@ -5,7 +5,6 @@
 //
 //
 
-#pragma once
 #ifndef _DETOURS_H_
 #define _DETOURS_H_
 
@@ -239,8 +238,6 @@ typedef UINT64 ULONG_PTR;
 #endif
 
 #ifdef DETOURS_INTERNAL
-
-#pragma warning(disable:4615) // unknown warning type (suppress with older compilers)
 
 #ifndef _Benign_race_begin_
 #define _Benign_race_begin_
@@ -620,10 +617,7 @@ LONG InterlockedCompareExchange(_Inout_ LONG *ptr, _In_ LONG nval, _In_ LONG ova
     return (LONG)__sync_val_compare_and_swap(ptr, oval, nval);
 }
 #else
-#pragma warning(push)
-#pragma warning(disable:4091) // empty typedef
 #include <dbghelp.h>
-#pragma warning(pop)
 #endif
 
 #if defined(_INC_STDIO) && !defined(_CRT_STDIO_ARBITRARY_WIDE_SPECIFIERS)

--- a/LinuxDetours/disasm.cpp
+++ b/LinuxDetours/disasm.cpp
@@ -3,10 +3,6 @@
 //  Detours Disassembler
 //
 
-#if _MSC_VER >= 1900
-#pragma warning(push)
-#pragma warning(disable:4091) // empty typedef
-#endif
 
 #define _ARM_WINAPI_PARTITION_DESKTOP_SDK_AVAILABLE 1
 #include "types.h"
@@ -17,10 +13,6 @@
 #define DETOURS_INTERNAL
 
 //#include "detours.h"
-
-#if _MSC_VER >= 1900
-#pragma warning(pop)
-#endif
 
 #undef ASSERT
 #define ASSERT(x)
@@ -149,9 +141,6 @@
 //      targets remain constant.  It does so by adjusting any IP relative
 //      offsets.
 //
-
-#pragma data_seg(".detourd")
-#pragma const_seg(".detourc")
 
 //////////////////////////////////////////////////// X86 and X64 Disassembler.
 //
@@ -2141,7 +2130,6 @@ UINT DETOUR_IA64_BUNDLE::Copy(_Out_ DETOUR_IA64_BUNDLE *pDst,
 {
     // Copy the bytes unchanged.
 
-#pragma warning(suppress:6001) // using uninitialized *pDst
     pDst->wide[0] = wide[0];
     pDst->wide[1] = wide[1];
 


### PR DESCRIPTION
Remove unused pragma statements that are used by the MSVC toolset but aren't used by our compiler on Linux, which is clang++.